### PR TITLE
Add route for PUT /login to accommodate login data in JSON format.

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -12,8 +12,9 @@ pwd_context = PasswordHasher()
 
 
 def hash_password(password: str | bytes) -> str:
-    """Hash a password using Argon2.
+    """Hash a password using Argon2, suitable for saving as user's password.
 
+       :param password: plain text password to hash
        :returns: hashed password
     """
     return pwd_context.hash(password)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 from typing import Annotated
-from fastapi import APIRouter, Depends, status, HTTPException
+from fastapi import APIRouter, Depends, status, HTTPException, Request
 from fastapi.security.oauth2 import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
@@ -29,7 +29,7 @@ async def loginform():
 
 @router.post('/login', response_model=schemas.Token)
 async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
-          session: Session = Depends(database.db.get_session)):
+                session: Session = Depends(database.db.get_session)):
     """Authenticate user and return a JWT token for this session.
 
     :param form_data: data from login form, containing 'username' and 'password' fields
@@ -41,15 +41,60 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     try:
         email = form_data.username
         password = form_data.password
-        logging.warning(f"Login for {email} with {password}")
-        assert email is not None
-        assert password is not None
     except Exception:
+        logging.warning(f"Login failed for {email}. POST form data invalid.")
+        # Response should probably be 422 Unprocessable Entity
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                             detail="Missing user email or password"
                             )
+    access_token = await validate_login(email, password, session)
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.put('/login', response_model=schemas.Token)
+async def login_json(login_data: schemas.LoginData,
+                     request: Request,
+                     session: Session = Depends(database.db.get_session)):
+    """Authenticate user using JSON input values and return a JWT token.
+
+    :param request: PUT request containing username=value, passowrd=value
+    :returns: JSON access token. Format of body is 
+              {"access_token": "jwt-token-value", "token_type": "bearer" }
+
+    The `grant_type` should always be `password` (the OAuth2 flow).
+    """
+    content_type = request.headers.get("content-type", "").lower()
+
+    if not content_type.startswith("application/json"):
+        logging.warning(f"Login failed for {email}. Content type {content_type} not supported.")
+        raise HTTPException(status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, 
+                            detail="Unsupported Content-Type")
+    try:
+        # username field value is expected to be an email address
+        email = login_data.username
+        password = login_data.password
+    except Exception:
+        logging.warning(f"Login failed for {email}. JSON data missing username or password.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Invalid JSON body")
+    access_token = await validate_login(email, password, session)
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+async def validate_login(email: str, 
+                        password: str,
+                        session: Session) -> dict[str, str]:
+    """Validate user credentials and return a JWT access token.
+
+    If any errors, raises HTTPException.
+    """
+    if not email or not password:
+        logging.warning(f"Login failed for {email}. Missing username or password.")
+        HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                      detail="Username and password may not be empty.")
     user = await user_dao.get_by_email(session, email=email)
     if not user:
+        logging.warning(f"Login failed for {email}. Unknown user.")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid Credentials",
@@ -57,20 +102,20 @@ async def login(form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
             )
     hashed_password = await user_dao.get_password(session, user)
     if not hashed_password:
+        logging.warning(f"Login failed for {email}. User has no local password.")
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User does not have local password credential",
             headers={"WWW-Authenticate": "Bearer"}
             )
-
     if not security.verify_password(hashed_password=hashed_password, plain_password=password):
+        logging.warning(f"Login failed for {email} with {password}. Invalid credentials.")
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid Credentials",
             headers={"WWW-Authenticate": "Bearer"}
             )
-
     # create and return a token
     access_token = jwt.create_access_token(data={"user_id": user.id})
-
-    return {"access_token": access_token, "token_type": "bearer"}
+    logging.info(f"Login success for {email} Access token granted.")
+    return access_token

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -69,6 +69,13 @@ class User(UserCreate):
     model_config = ConfigDict(from_attributes=True)
 
 
+class LoginData(BaseModel):
+    """Request body for PUT or POST request to login."""
+    # RFC 5321: max length of an email address is 254 chars. See Wiki for Pydantic's limits.
+    username: EmailStr = Field(..., max_length=MAX_EMAIL)
+    password: str = Field(..., max_length=MAX_NAME)
+
+
 class DataSourceCreate(BaseModel):
     """Schema for creating a new DataSource."""
     name: str = Field(..., max_length=MAX_NAME)

--- a/backend/tests/fixtures.py
+++ b/backend/tests/fixtures.py
@@ -24,8 +24,9 @@
 """
 # flake8: noqa: D401 First line should be in imperative mood
 
+from typing import Generator
 import pytest, pytest_asyncio
-from fastapi.testclient import TestClient
+import fastapi.testclient
 from app.core import security
 from app.core.database import db
 # Must import models so that db.create_tables() can create the table schema
@@ -79,6 +80,13 @@ async def async_client():
     from httpx import AsyncClient
     async with AsyncClient(app=main.app) as client:
         yield client
+
+
+@pytest.fixture()
+def client(): # -> Generator[fastapi.testclient.TestClient]
+    """Test fixture for calls to FastAPI route endpoints."""
+    # main.app.dependency_overrides[get_session] = db.get_session
+    yield fastapi.testclient.TestClient(main.app)
 
 
 @pytest_asyncio.fixture()
@@ -147,10 +155,3 @@ async def ds2(session, user2: models.User) -> models.DataSource:
     await session.commit()
     await session.refresh(ds)
     return ds
-
-
-@pytest.fixture()
-def client():
-    """Test fixture for calls to FastAPI route endpoints."""
-    # main.app.dependency_overrides[get_session] = db.get_session
-    yield TestClient(main.app)


### PR DESCRIPTION
Add PUT /login endpoint to handle login requests using application/json format for payload.  This is a cludge to avoid complicating the POST /login handler,
which must accept form-urlencoded payload.

Also added
- tests for both endpoints
- new `LoginData` schema class for parsing login data as JSON
- better comments in app/core/security.py: `hash_password`.